### PR TITLE
Allow opt-in for verbose output

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ with_lock do
 end
 `````
 
+The `with_lock` method will be useful when hitting the caveats of `LOCK=NONE`. Please read the 'Caveats' section.
+
 ### Enable verbose output
 To enable an 'ONLINE MIGRATION' debug statement whenever an online migration is
 run, simply set the `MysqlOnlineMigrations.verbose` module variable to true.
@@ -61,8 +63,6 @@ Example (in a Rails app's config/initializers/mysql_online_migrations.rb):
 ````
 MysqlOnlineMigrations.verbose = true
 ````
-
-The `with_lock` method will be useful when hitting the caveats of `LOCK=NONE`. Please read the following section.
 
 Caveats
 =======================

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 mysql_online_migrations
 =======================
 
-Patch Rails migrations to enforce MySQL 5.6 online migrations  
+Patch Rails migrations to enforce MySQL 5.6 online migrations
 Prior to MySQL 5.6, when adding / removing / renaming indexes and columns, MySQL would lock the writes of the whole table.
-MySQL 5.6 by default will try to apply the least locking possible. You however don't know what kind of locking it applies and there's situations where it can't allow writes during a migration (See Caveats).  
+MySQL 5.6 by default will try to apply the least locking possible. You however don't know what kind of locking it applies and there's situations where it can't allow writes during a migration (See Caveats).
 This gem enforces `LOCK=NONE` in all migration statements of Rails. Therefore, you're getting an error when MySQL cannot write during the migration so there's no surprise when rolling out in production.
 
 
@@ -53,6 +53,14 @@ with_lock do
   add_index :my_table, :my_field
 end
 `````
+
+### Enable verbose output
+To enable an 'ONLINE MIGRATION' debug statement whenever an online migration is
+run, simply set the `MysqlOnlineMigrations.verbose` module variable to true.
+Example (in a Rails app's config/initializers/mysql_online_migrations.rb):
+````
+MysqlOnlineMigrations.verbose = true
+````
 
 The `with_lock` method will be useful when hitting the caveats of `LOCK=NONE`. Please read the following section.
 

--- a/lib/mysql_online_migrations.rb
+++ b/lib/mysql_online_migrations.rb
@@ -7,6 +7,9 @@ require "active_record/connection_adapters/mysql2_adapter"
 end
 
 module MysqlOnlineMigrations
+
+  class << self; attr_accessor :verbose; end
+
   def self.prepended(base)
     ActiveRecord::Base.send(:class_attribute, :mysql_online_migrations, :instance_writer => false)
     ActiveRecord::Base.send("mysql_online_migrations=", true)
@@ -22,7 +25,7 @@ module MysqlOnlineMigrations
       original_connection.instance_variable_get(:@delegate)
     end
 
-    @no_lock_adapter ||= ActiveRecord::ConnectionAdapters::Mysql2AdapterWithoutLock.new(@original_adapter)
+    @no_lock_adapter ||= ActiveRecord::ConnectionAdapters::Mysql2AdapterWithoutLock.new(@original_adapter, MysqlOnlineMigrations.verbose)
 
     if adapter_mode
       @no_lock_adapter
@@ -38,6 +41,7 @@ module MysqlOnlineMigrations
     yield
     ActiveRecord::Base.mysql_online_migrations = original_value
   end
+
 end
 
 ActiveRecord::Migration.send(:prepend, MysqlOnlineMigrations)

--- a/lib/mysql_online_migrations/mysql2_adapter_without_lock.rb
+++ b/lib/mysql_online_migrations/mysql2_adapter_without_lock.rb
@@ -1,11 +1,13 @@
 module ActiveRecord
   module ConnectionAdapters
     class Mysql2AdapterWithoutLock < Mysql2Adapter
+
       OPTIMIZABLE_DDL_REGEX = /^(alter|create (unique )? ?index|drop index) /i
       DDL_WITH_COMMA_REGEX = /^alter /i
       DDL_WITH_LOCK_NONE_REGEX = / LOCK=NONE\s*$/i
 
-      def initialize(mysql2_adapter)
+      def initialize(mysql2_adapter, verbose = false)
+        @verbose = verbose
         params = [:@connection, :@logger, :@connection_options, :@config].map do |sym|
           mysql2_adapter.instance_variable_get(sym)
         end
@@ -24,7 +26,7 @@ module ActiveRecord
         return "" unless ActiveRecord::Base.mysql_online_migrations
         return "" if sql =~ DDL_WITH_LOCK_NONE_REGEX
         comma_delimiter = (sql =~ DDL_WITH_COMMA_REGEX ? "," : "")
-        puts "ONLINE MIGRATION"
+        puts "ONLINE MIGRATION" if @verbose
         "#{comma_delimiter} LOCK=NONE"
       end
     end

--- a/spec/lib/mysql_online_migrations/mysql2_adapter_without_lock_spec.rb
+++ b/spec/lib/mysql_online_migrations/mysql2_adapter_without_lock_spec.rb
@@ -5,6 +5,11 @@ describe ActiveRecord::ConnectionAdapters::Mysql2AdapterWithoutLock do
     it "successfully instantiates a working adapter" do
       ActiveRecord::ConnectionAdapters::Mysql2AdapterWithoutLock.new(@adapter).should be_active
     end
+
+    it "successfully instantiates a working adapter with verbose output" do
+      instance = ActiveRecord::ConnectionAdapters::Mysql2AdapterWithoutLock.new(@adapter, true)
+      instance.instance_variable_get(:@verbose).should be_true
+    end
   end
 
   context "#lock_none_statement" do

--- a/spec/lib/mysql_online_migrations_spec.rb
+++ b/spec/lib/mysql_online_migrations_spec.rb
@@ -10,10 +10,12 @@ describe MysqlOnlineMigrations do
   end
 
   context "#connection" do
-    shared_examples_for "Mysql2AdapterWithoutLock created" do
+    shared_examples_for "Mysql2AdapterWithoutLock created" do |verbose|
       it "memoizes an instance of Mysql2AdapterWithoutLock" do
+        MysqlOnlineMigrations.verbose = verbose
+
         ActiveRecord::ConnectionAdapters::Mysql2AdapterWithoutLock.should_receive(:new)
-          .with(an_instance_of(ActiveRecord::ConnectionAdapters::Mysql2Adapter), nil).once.and_call_original
+          .with(an_instance_of(ActiveRecord::ConnectionAdapters::Mysql2Adapter), verbose).once.and_call_original
         3.times { migration.connection }
       end
     end
@@ -24,6 +26,10 @@ describe MysqlOnlineMigrations do
       end
 
       it_behaves_like "Mysql2AdapterWithoutLock created"
+    end
+
+    context 'when migrating with verbose output' do
+      it_behaves_like "Mysql2AdapterWithoutLock created", true
     end
 
     context 'when rolling back' do

--- a/spec/lib/mysql_online_migrations_spec.rb
+++ b/spec/lib/mysql_online_migrations_spec.rb
@@ -13,7 +13,7 @@ describe MysqlOnlineMigrations do
     shared_examples_for "Mysql2AdapterWithoutLock created" do
       it "memoizes an instance of Mysql2AdapterWithoutLock" do
         ActiveRecord::ConnectionAdapters::Mysql2AdapterWithoutLock.should_receive(:new)
-          .with(an_instance_of(ActiveRecord::ConnectionAdapters::Mysql2Adapter)).once.and_call_original
+          .with(an_instance_of(ActiveRecord::ConnectionAdapters::Mysql2Adapter), nil).once.and_call_original
         3.times { migration.connection }
       end
     end


### PR DESCRIPTION
This PR adds a module-level attribute that controls whether the 'ONLINE MIGRATION' message is output when migrations are ran. The default behavior is updated to suppress this message, and display it if `MysqlOnlineMigrations.verbose = true` is set. 

I've updated the specs and updated the README with the intended usage (in a Rails initializer).

Great gem, by the way. It was exactly what we were looking for. I made this change because the extra noise from the ONLINE MIGRATIONS output during rake db:reset seemed to have little value.

Please let me know if there's anything in this PR that needs changing.

Cheers,

Mark
