### PR TITLE
Add without_lock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
-source :rubygems
+source "https://rubygems.org"
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       mysql2
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     activemodel (4.0.2)
       activesupport (= 4.0.2)
@@ -39,14 +39,18 @@ GEM
       coderay (~> 1.0.5)
       method_source (~> 0.8)
       slop (~> 3.4)
-    rspec (2.14.1)
-      rspec-core (~> 2.14.0)
-      rspec-expectations (~> 2.14.0)
-      rspec-mocks (~> 2.14.0)
-    rspec-core (2.14.7)
-    rspec-expectations (2.14.4)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.14.4)
+    rspec (3.1.0)
+      rspec-core (~> 3.1.0)
+      rspec-expectations (~> 3.1.0)
+      rspec-mocks (~> 3.1.0)
+    rspec-core (3.1.7)
+      rspec-support (~> 3.1.0)
+    rspec-expectations (3.1.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.1.0)
+    rspec-mocks (3.1.3)
+      rspec-support (~> 3.1.0)
+    rspec-support (3.1.2)
     slop (3.4.6)
     thread_safe (0.1.3)
       atomic

--- a/gemfiles/rails3.gemfile
+++ b/gemfiles/rails3.gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source "https://rubygems.org"
 gem "activerecord", "3.2.16"
 gem "activesupport", "3.2.16"
 gem "mysql2"

--- a/gemfiles/rails4.gemfile
+++ b/gemfiles/rails4.gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source "https://rubygems.org"
 gem "activerecord", "4.0.2"
 gem "activesupport", "4.0.2"
 gem "mysql2"

--- a/lib/mysql_online_migrations.rb
+++ b/lib/mysql_online_migrations.rb
@@ -32,9 +32,19 @@ module MysqlOnlineMigrations
     end
   end
 
-  def with_lock
+  def with_lock(&blk)
+    with_enabled_online_migrations(false, &blk)
+  end
+
+  def without_lock(&blk)
+    with_enabled_online_migrations(true, &blk)
+  end
+
+  private
+
+  def with_enabled_online_migrations(enabled)
     original_value = ActiveRecord::Base.mysql_online_migrations
-    ActiveRecord::Base.mysql_online_migrations = false
+    ActiveRecord::Base.mysql_online_migrations = enabled
     yield
     ActiveRecord::Base.mysql_online_migrations = original_value
   end

--- a/spec/lib/mysql_online_migrations_spec.rb
+++ b/spec/lib/mysql_online_migrations_spec.rb
@@ -5,7 +5,7 @@ describe MysqlOnlineMigrations do
 
   context ".prepended" do
     it "sets ActiveRecord::Base.mysql_online_migrations to true" do
-      ActiveRecord::Base.mysql_online_migrations.should be_true
+      ActiveRecord::Base.mysql_online_migrations.should be_truthy
     end
   end
 
@@ -43,22 +43,22 @@ describe MysqlOnlineMigrations do
 
   context "#with_lock" do
     it "switches mysql_online_migrations flag to false and then back to original value after block execution" do
-      ActiveRecord::Base.mysql_online_migrations.should be_true
+      ActiveRecord::Base.mysql_online_migrations.should be_truthy
       migration.with_lock do
-        ActiveRecord::Base.mysql_online_migrations.should be_false
+        ActiveRecord::Base.mysql_online_migrations.should be_falsy
       end
-      ActiveRecord::Base.mysql_online_migrations.should be_true
+      ActiveRecord::Base.mysql_online_migrations.should be_truthy
     end
   end
 
   context "#without_lock" do
     it "switches mysql_online_migrations flag to true and then back to original value after block execution" do
       ActiveRecord::Base.mysql_online_migrations = false
-      ActiveRecord::Base.mysql_online_migrations.should be_false
+      ActiveRecord::Base.mysql_online_migrations.should be_falsy
       migration.without_lock do
-        ActiveRecord::Base.mysql_online_migrations.should be_true
+        ActiveRecord::Base.mysql_online_migrations.should be_truthy
       end
-      ActiveRecord::Base.mysql_online_migrations.should be_false
+      ActiveRecord::Base.mysql_online_migrations.should be_falsy
     end
   end
 end

--- a/spec/lib/mysql_online_migrations_spec.rb
+++ b/spec/lib/mysql_online_migrations_spec.rb
@@ -50,4 +50,15 @@ describe MysqlOnlineMigrations do
       ActiveRecord::Base.mysql_online_migrations.should be_true
     end
   end
+
+  context "#without_lock" do
+    it "switches mysql_online_migrations flag to true and then back to original value after block execution" do
+      ActiveRecord::Base.mysql_online_migrations = false
+      ActiveRecord::Base.mysql_online_migrations.should be_false
+      migration.without_lock do
+        ActiveRecord::Base.mysql_online_migrations.should be_true
+      end
+      ActiveRecord::Base.mysql_online_migrations.should be_false
+    end
+  end
 end


### PR DESCRIPTION
Hi, Great gem!

If one has already a lot of legacy migrations and want to be able to run them without modifying, this strategy is required:
1. disable globally `mysql_online_migrations`
2. use it on new migrations wrapping in block in similar fashion to `with_lock`

This PR covers implementation of `without_lock` helper that is just plain analogy

closes #10 

/cc @anthonyalberto 
